### PR TITLE
Make it work on Windows 95

### DIFF
--- a/src/Civ2UIAL_FormOptions.xml
+++ b/src/Civ2UIAL_FormOptions.xml
@@ -29,7 +29,9 @@ Input wait time is the amount of time to sleep when waiting for user inputs. Hig
 
 Input wait time threshold is the period of time with no user inputs before increasing the sleep time.
 
-Input processing time threshold is the time taken to process user inputs before increasing CPU usage. Lower threshold can reduce input lag during heavy processing.">
+Input processing time threshold is the time taken to process user inputs before increasing CPU usage. Lower threshold can reduce input lag during heavy processing.
+
+This patch doesn't work on Windows 95.">
 				<integer key="MessagesPurgeIntervalMs" name="Purge input buffer interval in milliseconds"/>
 				<integer key="MessageWaitTimeMinMs" name="Minimum input wait time in milliseconds"/>
 				<integer key="MessageWaitTimeMaxMs" name="Maximum input wait time in milliseconds"/>

--- a/src/Patches/UiaPatchCPUUsage.pas
+++ b/src/Patches/UiaPatchCPUUsage.pas
@@ -94,16 +94,32 @@ begin
   end;
   Result := Round(dNow - g_dTimerStart);
 end;
-
 function C2PatchPeekMessageEx(var lpMsg: TMsg; hWnd: hWnd; wMsgFilterMin, wMsgFilterMax, wRemoveMsg: UINT): BOOL; stdcall;
 const
   MWMO_INPUTAVAILABLE = $0004;
 var
+  Handle: HMODULE;
+  MsgWaitForMultipleObjectsEx: function(nCount: DWORD; var pHandles; dwMilliseconds, dwWakeMask, dwFlags: DWORD): DWORD; stdcall;
   dBeginTime: Double;
   dNow: Double;
   dwMsgWaitResult: DWORD;
   msg: TMsg;
 begin
+  // Check if MsgWaitForMultipleObjectsEx exists (it does not on Windows 95).
+  Handle := LoadLibrary('user32');
+  if Handle = 0 then
+  begin
+    Result := False;
+    Exit;
+  end;
+  @MsgWaitForMultipleObjectsEx := GetProcAddress(Handle, 'MsgWaitForMultipleObjectsEx');
+  if @MsgWaitForMultipleObjectsEx = nil then
+  begin
+    FreeLibrary(Handle);
+    Result := False;
+    Exit;
+  end;
+
   dBeginTime := C2PatchGetTimerCurrentTime();
   // Civilization 2 uses filter value 957 as a spinning wait.
   if (wMsgFilterMin = 957) then

--- a/src/Patches/UiaPatchPowerGraph.pas
+++ b/src/Patches/UiaPatchPowerGraph.pas
@@ -22,6 +22,7 @@ uses
   Types,
   SysUtils,
   Windows,
+  CommCtrl,
   Civ2Types,
   Civ2Proc,
   Civ2UIA_Proc,
@@ -534,7 +535,7 @@ begin
     Tme.cbSize := SizeOf(TTrackMouseEvent);
     Tme.dwFlags := TME_LEAVE;
     Tme.hwndTrack := HWindow;
-    TrackMouseEvent(Tme);
+    _TrackMouseEvent(@Tme);
     MouseInClient := True
   end;
   // Determine Slot


### PR DESCRIPTION
Two functions are missing in USER32.DLL:
- TrackMouseEvent is the simpler one. Commctrl.dll contains _TrackMouseEvent, a wrapper that on 98/NT 4.0 and up invokes TrackMouseEvent but implements that function on 95. Requires Internet Explorer 3.0.
- MsgWaitForMultipleObjectsEx doesn't have a direct equivalent in 95. The closest thing is MsgWaitForMultipleObjects, which doesn't have dwFlags argument. Since it's in Patch CPU Usage, I just made this function load dynamically and return immediately if it isn't found. I also added a line to strings that it doesn't work.